### PR TITLE
Remove faraday from Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,8 +52,6 @@ GEM
     debug_inspector (0.0.2)
     erubis (2.7.0)
     execjs (2.6.0)
-    faraday (0.9.2)
-      multipart-post (>= 1.2, < 3)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     i18n (0.7.0)


### PR DESCRIPTION
Current version of faraday in gemfile.lock for lab causes version issues with Rails and Bundler and makes running the lab impossible